### PR TITLE
fix no such file of github.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ driver: src/vendor/github.com/xiezhenye/go-sql-driver-mysql
 src/vendor/github.com/xiezhenye/go-sql-driver-mysql:
 	mkdir -p src/vendor
 	GOPATH=$(pwd) go get github.com/xiezhenye/go-sql-driver-mysql
-	mv github.com src/vendor
+	mv src/github.com src/vendor
 
 mysqlburst: driver mysqlburst.go src/burst/*.go
 	GOPATH=$(pwd) go build mysqlburst.go


### PR DESCRIPTION
原 Makefile make 时会报错：
``` shell
mv: 无法获取"github.com" 的文件状态(stat): 没有那个文件或目录
make: *** [src/vendor/github.com/xiezhenye/go-sql-driver-mysql] 错误 1
```
github.com 的正确路径是 src/github.com